### PR TITLE
fix: use `let` for E995

### DIFF
--- a/autoload/yank_remote_url.vim
+++ b/autoload/yank_remote_url.vim
@@ -114,7 +114,7 @@ function! s:find_git_root() abort
     if isdirectory(l:path .. '/.git')
       return l:path
     endif
-    const l:modified = fnamemodify(l:path, ':h')
+    let l:modified = fnamemodify(l:path, ':h')
     if l:modified ==# l:path
       " is /
       return ''


### PR DESCRIPTION
`l:` is function local scope.

If use it with `while` loop, occur error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor internal variable declaration update in the Git-related utility function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->