### PR TITLE
feat: make configurable for line separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This plugin provides some functions:
     default: `v:true`
 
 - `yank_remote_url#remote_separator_dict`
-    Some registry use `+` or `-` as separator for url.
+    Some registries use `+` or `-` as a separator for url.
     eg: `https://github.com/Omochice/yank-remote-url.vim/blob/main/doc/yank_remote_url.txt#L1+L5`.
     This dictionary has the separator and URL match table.
     default: `{ 'github.com': '+', 'gitlab': '-', 'gitbucket': '+' }`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ This plugin provides some functions:
     If disable this, use current branch name instead.
     default: `v:true`
 
+- `yank_remote_url#remote_separator_dict`
+    Some registry use `+` or `-` as separator for url.
+    eg: `https://github.com/Omochice/yank-remote-url.vim/blob/main/doc/yank_remote_url.txt#L1+L5`.
+    This dictionary has the separator and URL match table.
+    default: `{ 'github.com': '+', 'gitlab': '-', 'gitbucket': '+' }`
+
 
 ## License
 

--- a/autoload/yank_remote_url.vim
+++ b/autoload/yank_remote_url.vim
@@ -63,7 +63,7 @@ const s:default_remote_separator_dict = {
       \ }
 
 function! s:get_line_separator(url) abort
-  for [regexp, separtor] in items(get(g:, 'yank_remote_url#remote_separator_dict', s:default_remote_separator_dict))
+  for [regexp, separator] in items(get(g:, 'yank_remote_url#remote_separator_dict', s:default_remote_separator_dict))
     if a:url =~# regexp
       return separator
     endif

--- a/doc/yank_remote_url.txt
+++ b/doc/yank_remote_url.txt
@@ -36,7 +36,7 @@ COMMANDS					*yank-remote-url-commands*
 FUNCTIONS					*yank-remote-url-functions*
 
 					*yank_remote_url#generate_url()*
-- `yank_remote_url#generate_url({line1}[, {line2}])`	
+- `yank_remote_url#generate_url({line1}[, {line2}])`
 	Generate remote url that show `line1` [to `line2`].
 	If the code is not tracked or the repository has no remote repository
 	etc, show error and return empty string.
@@ -73,6 +73,14 @@ VARIABLES					*yank-remote-url-variables*
 	Use HEAD commit hash to generate url.
 	If disable this, use current branch name instead.
 	default: |v:true|
+
+					*yank_remote_url#remote_separator_dict*
+- `yank_remote_url#remote_separator_dict`
+	Some registry use `+` or `-` as separator for url.
+	eg: `https://github.com/Omochice/yank-remote-url.vim/blob/main/doc/yank_remote_url.txt#L1+L5`.
+	This dictionary has the separator and URL match table.
+	default: `{ 'github.com': '+', 'gitlab': '-', 'gitbucket': '+' }`
+
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:

--- a/doc/yank_remote_url.txt
+++ b/doc/yank_remote_url.txt
@@ -76,7 +76,7 @@ VARIABLES					*yank-remote-url-variables*
 
 					*yank_remote_url#remote_separator_dict*
 - `yank_remote_url#remote_separator_dict`
-	Some registry use `+` or `-` as separator for url.
+	Some registries use `+` or `-` as a separator for url.
 	eg: `https://github.com/Omochice/yank-remote-url.vim/blob/main/doc/yank_remote_url.txt#L1+L5`.
 	This dictionary has the separator and URL match table.
 	default: `{ 'github.com': '+', 'gitlab': '-', 'gitbucket': '+' }`


### PR DESCRIPTION
- **feat: make configurable line separator by user**
- **docs: add documents for `yank_remote_url#remote_separator_dict`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configurable URL separator for different Git registries.
	- Introduced `yank_remote_url#remote_separator_dict` to customize URL formatting.

- **Documentation**
	- Updated documentation to reflect new URL separator configuration.
	- Removed deprecated functions and variables.

- **Refactor**
	- Improved line separator determination for remote URLs.
	- Streamlined remote URL handling logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->