### PR TITLE
feat: avoid to depend `systemlist`

### DIFF
--- a/autoload/yank_remote_url.vim
+++ b/autoload/yank_remote_url.vim
@@ -113,7 +113,8 @@ function! s:get_remote_url(git_root, origin) abort
 endfunction
 
 function s:get_current_revision_info(git_root) abort
-  const l:head_file = a:git_root .. '/.git/HEAD'
+  const l:git_dir = a:git_root .. '/.git'
+  const l:head_file = l:git_dir .. '/HEAD'
   if !filereadable(l:head_file)
     return #{
           \ ok: v:false,
@@ -135,7 +136,7 @@ function s:get_current_revision_info(git_root) abort
           \ }
   endif
   const l:branch_name = l:head_content->substitute('^ref: refs/heads/', '', '')
-  const l:commit_hash = readfile('.git/' .. substitute(l:head_content, '^ref: ', '', ''))->get(0, v:null)
+  const l:commit_hash = readfile(l:git_dir .. '/' .. substitute(l:head_content, '^ref: ', '', ''))->get(0, v:null)
   if l:commit_hash ==# v:null
     return #{
           \ ok: v:false,

--- a/autoload/yank_remote_url.vim
+++ b/autoload/yank_remote_url.vim
@@ -30,9 +30,9 @@ function s:set_cache() abort
   if !l:git_root.ok
     return l:git_root
   endif
-  const l:res = s:get_current_revision_info(l:git_root.value)
-  if !l:res.ok
-    return l:res
+  const l:revision = s:get_current_revision_info(l:git_root.value)
+  if !l:revision.ok
+    return l:revision
   endif
   const l:url = s:get_remote_url(
     \ l:git_root.value,
@@ -43,8 +43,8 @@ function s:set_cache() abort
   endif
   let b:yank_remote_url_cache = #{
         \ remote_url: s:normalize_url(l:url.value),
-        \ current_branch: l:res.value.branch,
-        \ current_hash: l:res.value.commit,
+        \ current_branch: l:revision.value.branch,
+        \ current_hash: l:revision.value.commit,
         \ git_root: l:git_root.value,
         \ path: expand('%')
         \       ->fnamemodify(':p')


### PR DESCRIPTION
`systemlist` is _heavy_ function.

So, use `readfile` to load config files.

some regexps are depends `nomagic`/`magic`, but this plugin is used by only me.

Hard-coded `magic` does not occur error currently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for remote URL generation
	- Enhanced robustness of git repository detection and URL retrieval

- **Refactor**
	- Restructured functions to provide more detailed and structured responses
	- Updated function signatures to support more comprehensive error checking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->