### PR TITLE
docs: add language marker

### DIFF
--- a/doc/yank_remote_url.txt
+++ b/doc/yank_remote_url.txt
@@ -21,12 +21,12 @@ COMMANDS					*yank-remote-url-commands*
 - YankRemoteURL					*YankRemoteURL*
 	Yank URL that show selected code line(s) on GitHub etc.
 	If you want to yank current line, run below:
->
+>vim
 	:YankRemoteURL
 <
 
 	If you want to yank multiple lines:
->
+>vim
 	:'<,'>YankRemoteURL
 <
 						*yank-remote-url-register*
@@ -40,7 +40,7 @@ FUNCTIONS					*yank-remote-url-functions*
 	Generate remote url that show `line1` [to `line2`].
 	If the code is not tracked or the repository has no remote repository
 	etc, show error and return empty string.
->
+>vim
 	call yank_remote_url#generate_url(1, 3)
 	" => like 'https://github.com/owner/repo/branch/blob/file#L1+L3'
 <
@@ -50,7 +50,7 @@ FUNCTIONS					*yank-remote-url-functions*
 	If the code is not tracked or the repository has no remote repository
 	etc, show error and return empty string.
 	About register, see |yank-remote-url-register|.
->
+>vim
 	call yank_remote_url#yank_url(1, 3)
 	" yank like 'https://github.com/owner/repo/branch/blob/file#L1+L3'
 <


### PR DESCRIPTION
vim9 support injection highlight on help.

It work on vim and nvim.
