### PR TITLE
refactor: stop to use `#` in augroup name

### DIFF
--- a/autoload/yank_remote_url.vim
+++ b/autoload/yank_remote_url.vim
@@ -19,7 +19,7 @@ endfunction
 
 function! yank_remote_url#_internal_enable_auto_cache() abort
   " register auto-cache
-  augroup yank_remote_url_origin#internal_augroup
+  augroup yank_remote_url_origin.internal_augroup
     autocmd!
     autocmd BufEnter * call timer_start(0, { -> s:set_cache() })
   augroup END


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized the naming of an internal autocommand group to align with project conventions.
  * No impact on user-facing behavior, configuration, or performance; all existing automation continues to function as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->